### PR TITLE
Added gist support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15474,6 +15474,14 @@
         }
       }
     },
+    "react-embed-gist": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/react-embed-gist/-/react-embed-gist-1.0.10.tgz",
+      "integrity": "sha512-c5Sn6tOkXXITFJ8sCS1qShLP++j32/5ImiVwwTgTG5dyLQyftF1WUtyk/r25B5zAR3FF1+/S5gYSorqQlM3Rug==",
+      "requires": {
+        "react": "^16.9.0"
+      }
+    },
     "react-error-overlay": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "prop-types": "^15.7.2",
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
+    "react-embed-gist": "^1.0.10",
     "react-feather": "^2.0.8"
   }
 }


### PR DESCRIPTION
- Allows us to embed formatted python notebook code into the documentation page.
- Tested on my own gist.
- Added [walkthrough](https://github.com/calpoly-csai/csai-docs/wiki/Add-Jupyter-Notebook-to-docs-page) to repo wiki.